### PR TITLE
Django 2.0 compatibility: Add mandatory `on_delete` argument to forei…

### DIFF
--- a/softdelete/migrations/0001_initial.py
+++ b/softdelete/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_date', models.DateTimeField(default=django.utils.timezone.now)),
                 ('object_id', models.CharField(max_length=100)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
             ],
         ),
         migrations.CreateModel(
@@ -27,8 +27,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_date', models.DateTimeField(default=django.utils.timezone.now)),
                 ('object_id', models.CharField(max_length=100)),
-                ('changeset', models.ForeignKey(related_name='soft_delete_records', to='softdelete.ChangeSet')),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('changeset', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='soft_delete_records', to='softdelete.ChangeSet')),
+                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -266,7 +266,7 @@ class SoftDeleteObject(models.Model):
 @python_2_unicode_compatible
 class ChangeSet(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.CharField(max_length=100)
     record = GenericForeignKey('content_type', 'object_id')
 
@@ -298,9 +298,13 @@ class ChangeSet(models.Model):
 
 @python_2_unicode_compatible
 class SoftDeleteRecord(models.Model):
-    changeset = models.ForeignKey(ChangeSet, related_name='soft_delete_records')
+    changeset = models.ForeignKey(
+        ChangeSet,
+        related_name='soft_delete_records',
+        on_delete=models.CASCADE
+    )
     created_date = models.DateTimeField(default=timezone.now)
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.CharField(max_length=100)
     record = GenericForeignKey('content_type', 'object_id')
 

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -5,18 +5,30 @@ from softdelete.admin import *
 
 class TestModelOne(SoftDeleteObject):
     extra_bool = models.BooleanField(default=False)
-    
+
 class TestModelTwo(SoftDeleteObject):
     extra_int = models.IntegerField()
-    tmo = models.ForeignKey(TestModelOne,related_name='tmts')
-    
+    tmo = models.ForeignKey(
+        TestModelOne,
+        on_delete=models.CASCADE,
+        related_name='tmts'
+    )
+
 class TestModelThree(SoftDeleteObject):
     tmos = models.ManyToManyField(TestModelOne, through='TestModelThrough')
     extra_int = models.IntegerField(blank=True, null=True)
 
 class TestModelThrough(SoftDeleteObject):
-    tmo1 = models.ForeignKey(TestModelOne, related_name="left_side")
-    tmo3 = models.ForeignKey(TestModelThree, related_name='right_side')
+    tmo1 = models.ForeignKey(
+        TestModelOne,
+        on_delete=models.CASCADE,
+        related_name="left_side"
+    )
+    tmo3 = models.ForeignKey(
+        TestModelThree,
+        on_delete=models.CASCADE,
+        related_name='right_side'
+    )
 
 
 admin.site.register(TestModelOne, SoftDeleteObjectAdmin)


### PR DESCRIPTION
…gn keys (#47)

* Add mandatory `on_delete` argument to foreign keys

* Add `on_delete` to foreign keys

* Include `on_delete` in migration

I'm intentionally adding this to the existing migration.

`makemigrations` do not create a new migration for the `on_delete`
changes to the fields.

I also tried adding a new model without the argument (and Django 1.11),
for which the migration _did_ include the argument (defaults to
`models.CASCADE`). If I explicitly removed the `on_delete` argument from
that migration, added `on_delete` to the model and ran `makemigrations`
again, it did not create a new migration.

So I assume it's safe to just add it to the existing migration, to make
it compatible with the most recent versions of Django.